### PR TITLE
Fixed some minnor errors

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -103,7 +103,7 @@ struct socks5_server g_server = {
 };
 
 int main (int argc, char **argv) {
-    if (socks5_server_parse(argc, argv) < 0) {
+    if (socks5_server_parse(argc, argv) < 1) {
         help();
         exit(EXIT_FAILURE);
     }

--- a/src/resolve.c
+++ b/src/resolve.c
@@ -53,13 +53,14 @@ static void dns_timer_setup_cb(struct dns_ctx *ctx, int timeout, void *data) {
 }
 
 int resolve_init(struct ev_loop *loop, char **nameservers, int nameserver_num) {
+    int i;
     if (NULL == nameservers) {
         dns_reset(g_ctx);
         dns_init(g_ctx, 0);
     } else {
         dns_reset(g_ctx);
 
-        for (int i = 0; i < nameserver_num; i++) {
+        for (i = 0; i < nameserver_num; i++) {
             dns_add_serv(g_ctx, nameservers[i]);
         }
     }


### PR DESCRIPTION
Hello mate!,

I just fixed two small bugs.

the first one was generating a compilation error in some old centos machine (loop initial declarations are only allowed in C99 mode).
the second one was just a logic error, if args < 0 should be if args < 1, now the help will be displayed if the binary is called without args.

great work by the way!!

thanks