### PR TITLE
Critical Fix

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -103,7 +103,7 @@ struct socks5_server g_server = {
 };
 
 int main (int argc, char **argv) {
-    if (socks5_server_parse(argc, argv) < 1) {
+    if (socks5_server_parse(argc, argv) < 0) {
         help();
         exit(EXIT_FAILURE);
     }


### PR DESCRIPTION
wont work at all with `socks5_server_parse(argc, argv) < 1`
the following function return -1 and 0 so < 1 includes both and always shows help menu .